### PR TITLE
Added package.json to Functions Framework for Node.js example

### DIFF
--- a/sample-functions-framework-node/package.json
+++ b/sample-functions-framework-node/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "sample-buildpack-functions-framework-node",
+  "version": "1.0.0",
+  "description": "Sample Buildpack with Functions Framework Node.js",
+  "main": "index.js",
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
Without the package.json file, the Node.js Functions Framework example gives the following error:

ERROR: No buildpack groups passed detection.
ERROR: Please check that you are running against the correct path.
ERROR: failed to detect: failed to detect: no buildpacks participating