### PR TITLE
Setting an Existing Node Version & Differentiating Output

### DIFF
--- a/sample-node-tsc/package.json
+++ b/sample-node-tsc/package.json
@@ -17,6 +17,6 @@
     "start": "node dist/web.js"
   },
   "engines": {
-    "node": "15.14.0"
+    "node": "16.18.1"
   }
 }

--- a/sample-node-tsc/web.ts
+++ b/sample-node-tsc/web.ts
@@ -3,7 +3,7 @@ import express from "express";
 const app = express();
 
 app.get('/', (req, res) => {
-  res.send('hello, TS world');
+  res.send('hello, world');
 });
 
 app.listen(process.env.PORT || 8080);

--- a/sample-node-tsc/web.ts
+++ b/sample-node-tsc/web.ts
@@ -3,7 +3,7 @@ import express from "express";
 const app = express();
 
 app.get('/', (req, res) => {
-  res.send('hello, world');
+  res.send('hello, TS world');
 });
 
 app.listen(process.env.PORT || 8080);


### PR DESCRIPTION
The currently configured Node version for the TypeScript sample, 15.14.0, is no longer available for download.

This pull request replaces that version with 16.18.1 which exists.

Additionally, it changes "`hello, world`" to "`hello, TS world`" because the same output is used for multiple containers, and it makes it easy to mask an error when the wrong container is run.